### PR TITLE
Updating spack in base images to allow for automatic update of version

### DIFF
--- a/ubuntu/16.04/Dockerfile
+++ b/ubuntu/16.04/Dockerfile
@@ -1,7 +1,9 @@
 FROM ubuntu:16.04@sha256:454054f5bbd571b088db25b662099c6c7b3f0cb78536a2077d54adc48f00cd68
 
-# docker build -t ghcr.io/llnl/radiuss-docker/ubuntu:<version> .
+# docker build -t ghcr.io/rse-radiuss/ubuntu:<version> .
 
+ARG uptodate_github_spack__spack=v0.16.2
+ENV spack_version=${uptodate_github_spack__spack}
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/Los_Angeles
 
@@ -22,7 +24,13 @@ RUN apt-get -qq update && \
       valgrind
 
 # Install spack
-RUN git clone --depth 1 https://github.com/spack/spack /opt/spack
+# Install spack
+WORKDIR /opt
+RUN wget https://github.com/spack/spack/archive/refs/tags/${spack_version}.tar.gz && \
+    tar -xzvf ${spack_version}.tar.gz && \
+    rm ${spack_version}.tar.gz && \
+    mkdir spack && \
+    tar -xzvf ${spack_version}.tar.gz -C spack  --strip-components 1
 ENV PATH=/opt/spack/bin:$PATH
 
 # Find packages already installed on system, e.g. autoconf

--- a/ubuntu/18.04/Dockerfile
+++ b/ubuntu/18.04/Dockerfile
@@ -2,6 +2,8 @@ FROM ubuntu:18.04@sha256:9bc830af2bef73276515a29aa896eedfa7bdf4bdbc5c1063b4c457a
 
 LABEL maintainer="Josh Essman <essman1@llnl.gov>, @vsoch"
 
+ARG uptodate_github_spack__spack=v0.16.2
+ENV spack_version=${uptodate_github_spack__spack}
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/Los_Angeles
 
@@ -21,7 +23,13 @@ RUN apt-get -qq update && \
       valgrind
 
 # Install spack
-RUN git clone --depth 1 https://github.com/spack/spack /opt/spack
+WORKDIR /opt
+RUN wget https://github.com/spack/spack/archive/refs/tags/${spack_version}.tar.gz && \
+    tar -xzvf ${spack_version}.tar.gz && \
+    rm ${spack_version}.tar.gz && \
+    mkdir spack && \
+    tar -xzvf ${spack_version}.tar.gz -C spack  --strip-components 1
+
 ENV PATH=/opt/spack/bin:$PATH
 
 # Find packages already installed on system, e.g. autoconf and install cmake

--- a/ubuntu/20.04/Dockerfile
+++ b/ubuntu/20.04/Dockerfile
@@ -2,6 +2,8 @@ FROM ubuntu:20.04@sha256:9d6a8699fb5c9c39cf08a0871bd6219f0400981c570894cd8cbea30
 
 LABEL maintainer="Chris White <white238@llnl.gov>,@vsoch"
 
+ARG uptodate_github_spack__spack=v0.16.2
+ENV spack_version=${uptodate_github_spack__spack}
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/Los_Angeles
 
@@ -28,7 +30,12 @@ RUN python3 -m pip install --upgrade pip && \
     python3 -m pip install clingo
 
 # Install spack
-RUN git clone --depth 1 https://github.com/spack/spack /opt/spack
+WORKDIR /opt
+RUN wget https://github.com/spack/spack/archive/refs/tags/${spack_version}.tar.gz && \
+    tar -xzvf ${spack_version}.tar.gz && \
+    rm ${spack_version}.tar.gz && \
+    mkdir spack && \
+    tar -xzvf ${spack_version}.tar.gz -C spack  --strip-components 1
 ENV PATH=/opt/spack/bin:$PATH
 
 # Find packages already installed on system, e.g. autoconf


### PR DESCRIPTION
This will test the new uptodate build arg updated to update the version of spack. Technically we are pointing at the latest version, so this won't trigger until later. The main difference is installing from a release that uses a build arg instead of clone.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>