### PR TITLE
Adding view and cache to base images

### DIFF
--- a/.github/workflows/build-matrices.yaml
+++ b/.github/workflows/build-matrices.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       dockerbuild_matrix: ${{ steps.dockerbuild.outputs.dockerbuild_matrix }}
-      empty_matrix: ${{ steps.check_matrix.outputs.empty_matrix }}
+      empty_matrix: ${{ steps.dockerbuild.outputs.dockerbuild_matrix_empty }}
 
     steps:
     # Using git in the container to diff means we explicitly need to checkout a branch
@@ -45,17 +45,14 @@ jobs:
         changes: true # only include changed uptodate.yaml
 
     - name: View and Check Build Matrix Result
-      id: empty_matrix
       env:
         result: ${{ steps.dockerbuild.outputs.dockerbuild_matrix }}
       run: |
         echo ${result}
         if [[ "${result}" == "" ]]; then
           printf "The matrix is empty, will not trigger next workflow.\n"
-          echo "::set-output name=empty_matrix::true"       
         else
           printf "The matrix is not empty, and we should continue on to the next workflow.\n"
-          echo "::set-output name=empty_matrix::false"          
         fi
 
   build:

--- a/.github/workflows/dockerfiles.yaml
+++ b/.github/workflows/dockerfiles.yaml
@@ -97,8 +97,10 @@ jobs:
       - name: View Build Matrix Result
         env:
           result: ${{ steps.dockerfile_list.outputs.dockerfilelist_matrix }}
+          is_empty: ${{ steps.dockerfile_list.outputs.dockerfilelist_matrix_empty }}
         run: |
           echo ${result}
+          echo ${is_empty}
           if [[ "${result}" == "[]" ]]; then
             printf "The matrix is empty, will not trigger next workflow.\n"
           else

--- a/.github/workflows/dockerfiles.yaml
+++ b/.github/workflows/dockerfiles.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       dockerfile_matrix: ${{ steps.dockerfile_list.outputs.dockerfilelist_matrix }}
-      empty_matrix: ${{ steps.empty_matrix.outputs.empty_matrix }}
+      empty_matrix: ${{ steps.dockerfile_list.outputs.dockerfilelist_matrix_empty }}
 
     steps:
 
@@ -91,21 +91,18 @@ jobs:
         with: 
           root: .
           parser: dockerfilelist
-          flags: "--no-build-args"
+          flags: "--no-empty-build-args"
           changes: true # only include changed files
 
-      - name: View and Check Build Matrix Result
-        id: empty_matrix
+      - name: View Build Matrix Result
         env:
           result: ${{ steps.dockerfile_list.outputs.dockerfilelist_matrix }}
         run: |
           echo ${result}
           if [[ "${result}" == "[]" ]]; then
             printf "The matrix is empty, will not trigger next workflow.\n"
-            echo "::set-output name=empty_matrix::true"       
           else
             printf "The matrix is not empty, and we should continue on to the next workflow.\n"
-            echo "::set-output name=empty_matrix::false"          
           fi
 
   build:

--- a/.github/workflows/dockerfiles.yaml
+++ b/.github/workflows/dockerfiles.yaml
@@ -113,7 +113,7 @@ jobs:
       fail-fast: false
       matrix:
         result: ${{ fromJson(needs.update.outputs.dockerfile_matrix) }}
-    if: ${{ needs.update.outputs.empty_matrix == false }}
+    if: ${{ needs.update.outputs.empty_matrix == 'false' }}
 
     name: "Build ${{ matrix.result.name }}"
     steps:

--- a/ubuntu/16.04/Dockerfile
+++ b/ubuntu/16.04/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:16.04@sha256:454054f5bbd571b088db25b662099c6c7b3f0cb78536a2077d54adc
 
 # docker build -t ghcr.io/rse-radiuss/ubuntu:<version> .
 
-ARG uptodate_github_commit_spack__spack__develop=0015f700b77247873d06ddd12c496ebb782d4713
+ARG uptodate_github_commit_spack__spack__develop=NA
 ENV spack_commit=${uptodate_github_commit_spack__spack__develop}
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/Los_Angeles

--- a/ubuntu/16.04/Dockerfile
+++ b/ubuntu/16.04/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:16.04@sha256:454054f5bbd571b088db25b662099c6c7b3f0cb78536a2077d54adc
 
 # docker build -t ghcr.io/rse-radiuss/ubuntu:<version> .
 
-ARG uptodate_github_commit_spack__spack__develop=NA
+ARG uptodate_github_commit_spack__spack__develop=c0122242ee90f0fe37edceb8d25f5ebd4a48cf19
 ENV spack_commit=${uptodate_github_commit_spack__spack__develop}
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/Los_Angeles

--- a/ubuntu/16.04/Dockerfile
+++ b/ubuntu/16.04/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:16.04@sha256:454054f5bbd571b088db25b662099c6c7b3f0cb78536a2077d54adc
 
 # docker build -t ghcr.io/rse-radiuss/ubuntu:<version> .
 
-ARG uptodate_github_commit_spack__spack__develop=NA
-ENV spack_version=${uptodate_github_commit_spack__spack__develop}
+ARG uptodate_github_commit_spack__spack__develop=0015f700b77247873d06ddd12c496ebb782d4713
+ENV spack_commit=${uptodate_github_commit_spack__spack__develop}
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/Los_Angeles
 
@@ -25,12 +25,10 @@ RUN apt-get -qq update && \
       gnupg2 
 
 # Install spack
-# Install spack
 WORKDIR /opt
-RUN wget https://github.com/spack/spack/archive/refs/tags/${spack_version}.tar.gz && \
-    mkdir spack && \
-    tar -xzvf ${spack_version}.tar.gz -C spack  --strip-components 1 && \
-    rm ${spack_version}.tar.gz
+RUN git clone https://github.com/spack/spack && \
+    cd spack && \
+    git reset --hard ${spack_commit}
 ENV PATH=/opt/spack/bin:$PATH
 
 # Use the autamus build cache for maybe faster install?

--- a/ubuntu/16.04/Dockerfile
+++ b/ubuntu/16.04/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:16.04@sha256:454054f5bbd571b088db25b662099c6c7b3f0cb78536a2077d54adc
 
 # docker build -t ghcr.io/rse-radiuss/ubuntu:<version> .
 
-ARG uptodate_github_spack__spack=v0.16.2
+ARG uptodate_github_commit_spack__spack__develop=v0.16.2
 ENV spack_version=${uptodate_github_spack__spack}
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/Los_Angeles
@@ -27,14 +27,15 @@ RUN apt-get -qq update && \
 # Install spack
 WORKDIR /opt
 RUN wget https://github.com/spack/spack/archive/refs/tags/${spack_version}.tar.gz && \
-    tar -xzvf ${spack_version}.tar.gz && \
-    rm ${spack_version}.tar.gz && \
     mkdir spack && \
-    tar -xzvf ${spack_version}.tar.gz -C spack  --strip-components 1
+    tar -xzvf ${spack_version}.tar.gz -C spack  --strip-components 1 && \
+    rm ${spack_version}.tar.gz
 ENV PATH=/opt/spack/bin:$PATH
 
 # Find packages already installed on system, e.g. autoconf
 RUN spack external find && \
-
     # Install a new CMake (used to be 3.10.1)
     spack install cmake@3.20.4
+
+RUN spack view symlink /opt/view cmake@3.20.4
+ENV PATH=/opt/view/bin:$PATH

--- a/ubuntu/16.04/Dockerfile
+++ b/ubuntu/16.04/Dockerfile
@@ -10,19 +10,21 @@ ENV TZ=America/Los_Angeles
 LABEL maintainer="David Beckingsale <david@llnl.gov>,@vsoch"
 
 RUN apt-get -qq update && \
-    apt-get -qq install -y --no-install-recommends wget \
+    apt-get -qq install -y --no-install-recommends \
+      build-essential \
+      ca-certificates \
+      curl \
+      dh-autoreconf \
+      git \
+      gnupg2 \
+      libssl-dev \
+      ninja-build \
       python-dev \ 
       python3-pip \
-      build-essential \
       sudo \
-      git \
-      vim \
-      dh-autoreconf \
-      ninja-build \
-      libssl-dev \
-      ca-certificates \
       valgrind \
-      gnupg2 
+      vim \
+      wget
 
 # Install spack
 WORKDIR /opt

--- a/ubuntu/16.04/Dockerfile
+++ b/ubuntu/16.04/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:16.04@sha256:454054f5bbd571b088db25b662099c6c7b3f0cb78536a2077d54adc
 
 # docker build -t ghcr.io/rse-radiuss/ubuntu:<version> .
 
-ARG uptodate_github_commit_spack__spack__develop=v0.16.2
-ENV spack_version=${uptodate_github_spack__spack}
+ARG uptodate_github_commit_spack__spack__develop=NA
+ENV spack_version=${uptodate_github_commit_spack__spack__develop}
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/Los_Angeles
 
@@ -21,7 +21,8 @@ RUN apt-get -qq update && \
       ninja-build \
       libssl-dev \
       ca-certificates \
-      valgrind
+      valgrind \
+      gnupg2 
 
 # Install spack
 # Install spack
@@ -31,6 +32,12 @@ RUN wget https://github.com/spack/spack/archive/refs/tags/${spack_version}.tar.g
     tar -xzvf ${spack_version}.tar.gz -C spack  --strip-components 1 && \
     rm ${spack_version}.tar.gz
 ENV PATH=/opt/spack/bin:$PATH
+
+# Use the autamus build cache for maybe faster install?
+RUN pip install botocore boto3 && \
+    spack mirror add autamus s3://autamus-cache && \
+    curl http://s3.amazonaws.com/autamus-cache/build_cache/_pgp/FFEB24B0A9D81F6D5597F9900B59588C86C41BE7.pub > key.pub && \
+    spack gpg trust key.pub
 
 # Find packages already installed on system, e.g. autoconf
 RUN spack external find && \

--- a/ubuntu/16.04/Dockerfile
+++ b/ubuntu/16.04/Dockerfile
@@ -32,7 +32,7 @@ RUN git clone https://github.com/spack/spack && \
 ENV PATH=/opt/spack/bin:$PATH
 
 # Use the autamus build cache for maybe faster install?
-RUN pip install botocore boto3 && \
+RUN python3 -m pip install botocore boto3 && \
     spack mirror add autamus s3://autamus-cache && \
     curl http://s3.amazonaws.com/autamus-cache/build_cache/_pgp/FFEB24B0A9D81F6D5597F9900B59588C86C41BE7.pub > key.pub && \
     spack gpg trust key.pub

--- a/ubuntu/18.04/Dockerfile
+++ b/ubuntu/18.04/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:18.04@sha256:9bc830af2bef73276515a29aa896eedfa7bdf4bdbc5c1063b4c457a
 
 LABEL maintainer="Josh Essman <essman1@llnl.gov>, @vsoch"
 
-ARG uptodate_github_commit_spack__spack__develop=NAA
+ARG uptodate_github_commit_spack__spack__develop=c0122242ee90f0fe37edceb8d25f5ebd4a48cf19
 ENV spack_commit=${uptodate_github_commit_spack__spack__develop}
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/Los_Angeles

--- a/ubuntu/18.04/Dockerfile
+++ b/ubuntu/18.04/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:18.04@sha256:9bc830af2bef73276515a29aa896eedfa7bdf4bdbc5c1063b4c457a
 
 LABEL maintainer="Josh Essman <essman1@llnl.gov>, @vsoch"
 
-ARG uptodate_github_commit_spack__spack__develop=NA
+ARG uptodate_github_commit_spack__spack__develop=NAA
 ENV spack_commit=${uptodate_github_commit_spack__spack__develop}
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/Los_Angeles

--- a/ubuntu/18.04/Dockerfile
+++ b/ubuntu/18.04/Dockerfile
@@ -31,7 +31,7 @@ RUN git clone https://github.com/spack/spack && \
 ENV PATH=/opt/spack/bin:$PATH
 
 # Use the autamus build cache for maybe faster install?
-RUN pip install botocore boto3 && \
+RUN python3 -m pip install botocore boto3 && \
     spack mirror add autamus s3://autamus-cache && \
     curl http://s3.amazonaws.com/autamus-cache/build_cache/_pgp/FFEB24B0A9D81F6D5597F9900B59588C86C41BE7.pub > key.pub && \
     spack gpg trust key.pub

--- a/ubuntu/18.04/Dockerfile
+++ b/ubuntu/18.04/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:18.04@sha256:9bc830af2bef73276515a29aa896eedfa7bdf4bdbc5c1063b4c457a
 
 LABEL maintainer="Josh Essman <essman1@llnl.gov>, @vsoch"
 
-ARG uptodate_github_spack__spack=v0.16.2
+ARG uptodate_github_commit_spack__spack__develop=v0.16.2
 ENV spack_version=${uptodate_github_spack__spack}
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/Los_Angeles
@@ -25,13 +25,14 @@ RUN apt-get -qq update && \
 # Install spack
 WORKDIR /opt
 RUN wget https://github.com/spack/spack/archive/refs/tags/${spack_version}.tar.gz && \
-    tar -xzvf ${spack_version}.tar.gz && \
-    rm ${spack_version}.tar.gz && \
     mkdir spack && \
-    tar -xzvf ${spack_version}.tar.gz -C spack  --strip-components 1
-
+    tar -xzvf ${spack_version}.tar.gz -C spack  --strip-components 1 && \
+    rm ${spack_version}.tar.gz
 ENV PATH=/opt/spack/bin:$PATH
 
 # Find packages already installed on system, e.g. autoconf and install cmake
 RUN spack external find && \
     spack install cmake@3.20.4
+
+RUN spack view symlink /opt/view cmake@3.20.4
+ENV PATH=/opt/view/bin:$PATH

--- a/ubuntu/18.04/Dockerfile
+++ b/ubuntu/18.04/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:18.04@sha256:9bc830af2bef73276515a29aa896eedfa7bdf4bdbc5c1063b4c457a
 
 LABEL maintainer="Josh Essman <essman1@llnl.gov>, @vsoch"
 
-ARG uptodate_github_commit_spack__spack__develop=0015f700b77247873d06ddd12c496ebb782d4713
+ARG uptodate_github_commit_spack__spack__develop=NA
 ENV spack_commit=${uptodate_github_commit_spack__spack__develop}
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/Los_Angeles

--- a/ubuntu/18.04/Dockerfile
+++ b/ubuntu/18.04/Dockerfile
@@ -9,19 +9,20 @@ ENV TZ=America/Los_Angeles
 
 RUN apt-get -qq update && \
     apt-get -qq install -y --no-install-recommends \
-      wget \
-      python3-dev \
-      python3-pip \
       build-essential \
-      sudo \
-      git \
-      vim \
-      dh-autoreconf \
-      ninja-build \
-      libssl-dev \
       ca-certificates \
+      curl \
+      dh-autoreconf \
+      git \
+      gnupg2 \
+      libssl-dev \
+      ninja-build \
+      python-dev \ 
+      python3-pip \
+      sudo \
       valgrind \
-      gnupg2
+      vim \
+      wget
 
 # Install spack
 WORKDIR /opt

--- a/ubuntu/18.04/Dockerfile
+++ b/ubuntu/18.04/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:18.04@sha256:9bc830af2bef73276515a29aa896eedfa7bdf4bdbc5c1063b4c457a
 
 LABEL maintainer="Josh Essman <essman1@llnl.gov>, @vsoch"
 
-ARG uptodate_github_commit_spack__spack__develop=NA
-ENV spack_version=${uptodate_github_commit_spack__spack__develop}
+ARG uptodate_github_commit_spack__spack__develop=0015f700b77247873d06ddd12c496ebb782d4713
+ENV spack_commit=${uptodate_github_commit_spack__spack__develop}
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/Los_Angeles
 
@@ -25,10 +25,9 @@ RUN apt-get -qq update && \
 
 # Install spack
 WORKDIR /opt
-RUN wget https://github.com/spack/spack/archive/refs/tags/${spack_version}.tar.gz && \
-    mkdir spack && \
-    tar -xzvf ${spack_version}.tar.gz -C spack  --strip-components 1 && \
-    rm ${spack_version}.tar.gz
+RUN git clone https://github.com/spack/spack && \
+    cd spack && \
+    git reset --hard ${spack_commit}
 ENV PATH=/opt/spack/bin:$PATH
 
 # Use the autamus build cache for maybe faster install?

--- a/ubuntu/18.04/Dockerfile
+++ b/ubuntu/18.04/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:18.04@sha256:9bc830af2bef73276515a29aa896eedfa7bdf4bdbc5c1063b4c457a
 
 LABEL maintainer="Josh Essman <essman1@llnl.gov>, @vsoch"
 
-ARG uptodate_github_commit_spack__spack__develop=v0.16.2
-ENV spack_version=${uptodate_github_spack__spack}
+ARG uptodate_github_commit_spack__spack__develop=NA
+ENV spack_version=${uptodate_github_commit_spack__spack__develop}
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/Los_Angeles
 
@@ -20,7 +20,8 @@ RUN apt-get -qq update && \
       ninja-build \
       libssl-dev \
       ca-certificates \
-      valgrind
+      valgrind \
+      gnupg2
 
 # Install spack
 WORKDIR /opt
@@ -29,6 +30,12 @@ RUN wget https://github.com/spack/spack/archive/refs/tags/${spack_version}.tar.g
     tar -xzvf ${spack_version}.tar.gz -C spack  --strip-components 1 && \
     rm ${spack_version}.tar.gz
 ENV PATH=/opt/spack/bin:$PATH
+
+# Use the autamus build cache for maybe faster install?
+RUN pip install botocore boto3 && \
+    spack mirror add autamus s3://autamus-cache && \
+    curl http://s3.amazonaws.com/autamus-cache/build_cache/_pgp/FFEB24B0A9D81F6D5597F9900B59588C86C41BE7.pub > key.pub && \
+    spack gpg trust key.pub
 
 # Find packages already installed on system, e.g. autoconf and install cmake
 RUN spack external find && \

--- a/ubuntu/20.04/Dockerfile
+++ b/ubuntu/20.04/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:20.04@sha256:9d6a8699fb5c9c39cf08a0871bd6219f0400981c570894cd8cbea30
 
 LABEL maintainer="Chris White <white238@llnl.gov>,@vsoch"
 
-ARG uptodate_github_spack__spack=v0.16.2
+ARG uptodate_github_commit_spack__spack__develop=v0.16.2
 ENV spack_version=${uptodate_github_spack__spack}
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/Los_Angeles
@@ -32,14 +32,15 @@ RUN python3 -m pip install --upgrade pip && \
 # Install spack
 WORKDIR /opt
 RUN wget https://github.com/spack/spack/archive/refs/tags/${spack_version}.tar.gz && \
-    tar -xzvf ${spack_version}.tar.gz && \
-    rm ${spack_version}.tar.gz && \
     mkdir spack && \
-    tar -xzvf ${spack_version}.tar.gz -C spack  --strip-components 1
+    tar -xzvf ${spack_version}.tar.gz -C spack  --strip-components 1 && \
+    rm ${spack_version}.tar.gz
 ENV PATH=/opt/spack/bin:$PATH
 
 # Find packages already installed on system, e.g. autoconf
 RUN spack external find && \
-
     # Install a new CMake
     spack install cmake@3.20.4
+
+RUN spack view symlink /opt/view cmake@3.20.4
+ENV PATH=/opt/view/bin:$PATH

--- a/ubuntu/20.04/Dockerfile
+++ b/ubuntu/20.04/Dockerfile
@@ -9,22 +9,24 @@ ENV TZ=America/Los_Angeles
 
 RUN apt-get -qq update && \
     apt-get -qq install -fy tzdata && \
-    apt-get -qq install -fy --no-install-recommends \
+    apt-get -qq install -y --no-install-recommends \
       build-essential \
       ca-certificates \
       curl \
       dh-autoreconf \
       git \
+      gnupg2 \
       lcov \
+      libssl-dev \
       ninja-build \
       pkg-config \
-      python3-dev \
+      python-dev \ 
       python3-pip \
-      libssl-dev \
       sudo \
+      valgrind \
+      vim \
       wget \
-      xsltproc \
-      gnupg2
+      xsltproc
 
 # Install Clingo for Spack
 RUN python3 -m pip install --upgrade pip && \

--- a/ubuntu/20.04/Dockerfile
+++ b/ubuntu/20.04/Dockerfile
@@ -38,7 +38,7 @@ RUN git clone https://github.com/spack/spack && \
 ENV PATH=/opt/spack/bin:$PATH
 
 # Use the autamus build cache for maybe faster install?
-RUN pip install botocore boto3 && \
+RUN python3 -m pip install botocore boto3 && \
     spack mirror add autamus s3://autamus-cache && \
     curl http://s3.amazonaws.com/autamus-cache/build_cache/_pgp/FFEB24B0A9D81F6D5597F9900B59588C86C41BE7.pub > key.pub && \
     spack gpg trust key.pub

--- a/ubuntu/20.04/Dockerfile
+++ b/ubuntu/20.04/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:20.04@sha256:9d6a8699fb5c9c39cf08a0871bd6219f0400981c570894cd8cbea30
 
 LABEL maintainer="Chris White <white238@llnl.gov>,@vsoch"
 
-ARG uptodate_github_commit_spack__spack__develop=0015f700b77247873d06ddd12c496ebb782d4713
+ARG uptodate_github_commit_spack__spack__develop=NA
 ENV spack_commit=${uptodate_github_commit_spack__spack__develop}
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/Los_Angeles

--- a/ubuntu/20.04/Dockerfile
+++ b/ubuntu/20.04/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:20.04@sha256:9d6a8699fb5c9c39cf08a0871bd6219f0400981c570894cd8cbea30
 
 LABEL maintainer="Chris White <white238@llnl.gov>,@vsoch"
 
-ARG uptodate_github_commit_spack__spack__develop=v0.16.2
-ENV spack_version=${uptodate_github_spack__spack}
+ARG uptodate_github_commit_spack__spack__develop=NA
+ENV spack_version=${uptodate_github_commit_spack__spack__develop}
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/Los_Angeles
 
@@ -23,7 +23,8 @@ RUN apt-get -qq update && \
       libssl-dev \
       sudo \
       wget \
-      xsltproc
+      xsltproc \
+      gnupg2
 
 # Install Clingo for Spack
 RUN python3 -m pip install --upgrade pip && \
@@ -36,6 +37,12 @@ RUN wget https://github.com/spack/spack/archive/refs/tags/${spack_version}.tar.g
     tar -xzvf ${spack_version}.tar.gz -C spack  --strip-components 1 && \
     rm ${spack_version}.tar.gz
 ENV PATH=/opt/spack/bin:$PATH
+
+# Use the autamus build cache for maybe faster install?
+RUN pip install botocore boto3 && \
+    spack mirror add autamus s3://autamus-cache && \
+    curl http://s3.amazonaws.com/autamus-cache/build_cache/_pgp/FFEB24B0A9D81F6D5597F9900B59588C86C41BE7.pub > key.pub && \
+    spack gpg trust key.pub
 
 # Find packages already installed on system, e.g. autoconf
 RUN spack external find && \

--- a/ubuntu/20.04/Dockerfile
+++ b/ubuntu/20.04/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:20.04@sha256:9d6a8699fb5c9c39cf08a0871bd6219f0400981c570894cd8cbea30
 
 LABEL maintainer="Chris White <white238@llnl.gov>,@vsoch"
 
-ARG uptodate_github_commit_spack__spack__develop=NA
+ARG uptodate_github_commit_spack__spack__develop=c0122242ee90f0fe37edceb8d25f5ebd4a48cf19
 ENV spack_commit=${uptodate_github_commit_spack__spack__develop}
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/Los_Angeles

--- a/ubuntu/20.04/Dockerfile
+++ b/ubuntu/20.04/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:20.04@sha256:9d6a8699fb5c9c39cf08a0871bd6219f0400981c570894cd8cbea30
 
 LABEL maintainer="Chris White <white238@llnl.gov>,@vsoch"
 
-ARG uptodate_github_commit_spack__spack__develop=NA
-ENV spack_version=${uptodate_github_commit_spack__spack__develop}
+ARG uptodate_github_commit_spack__spack__develop=0015f700b77247873d06ddd12c496ebb782d4713
+ENV spack_commit=${uptodate_github_commit_spack__spack__develop}
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/Los_Angeles
 
@@ -32,10 +32,9 @@ RUN python3 -m pip install --upgrade pip && \
 
 # Install spack
 WORKDIR /opt
-RUN wget https://github.com/spack/spack/archive/refs/tags/${spack_version}.tar.gz && \
-    mkdir spack && \
-    tar -xzvf ${spack_version}.tar.gz -C spack  --strip-components 1 && \
-    rm ${spack_version}.tar.gz
+RUN git clone https://github.com/spack/spack && \
+    cd spack && \
+    git reset --hard ${spack_commit}
 ENV PATH=/opt/spack/bin:$PATH
 
 # Use the autamus build cache for maybe faster install?

--- a/ubuntu/clang/Dockerfile
+++ b/ubuntu/clang/Dockerfile
@@ -5,12 +5,5 @@ FROM ghcr.io/rse-radiuss/ubuntu:$ubuntu_version
 ARG llvm_version
 ENV llvm_version=$llvm_version
 
-# Use the autamus build cache for maybe faster install?
-RUN apt-get update && apt-get install -y gnupg2 python3-dev python3-pip && \
-    pip install botocore boto3 && \
-    spack mirror add autamus s3://autamus-cache && \
-    curl http://s3.amazonaws.com/autamus-cache/build_cache/_pgp/FFEB24B0A9D81F6D5597F9900B59588C86C41BE7.pub > key.pub && \
-    spack gpg trust key.pub
-
 RUN spack install llvm@${llvm_version}
 RUN spack view symlink /opt/view llvm@${llvm_version}

--- a/ubuntu/clang/Dockerfile
+++ b/ubuntu/clang/Dockerfile
@@ -13,3 +13,4 @@ RUN apt-get update && apt-get install -y gnupg2 python3-dev python3-pip && \
     spack gpg trust key.pub
 
 RUN spack install llvm@${llvm_version}
+RUN spack view symlink /opt/view llvm@${llvm_version}

--- a/ubuntu/cuda/Dockerfile
+++ b/ubuntu/cuda/Dockerfile
@@ -6,3 +6,4 @@ ARG cuda_version
 ENV cuda_version=$cuda_version
 
 RUN spack install cuda@${cuda_version}
+RUN spack view symlink /opt/view cuda@${cuda_version}

--- a/ubuntu/gcc/Dockerfile
+++ b/ubuntu/gcc/Dockerfile
@@ -6,3 +6,4 @@ ARG gcc_version
 ENV gcc_version=$gcc_version
 
 RUN spack install gcc@${gcc_version}
+RUN spack view symlink /opt/view gcc@${gcc_version}

--- a/ubuntu/hip/Dockerfile
+++ b/ubuntu/hip/Dockerfile
@@ -6,3 +6,4 @@ ARG hip_version
 ENV hip_version=$hip_version
 
 RUN spack install hip@${hip_version}
+RUN spack view symlink /opt/view hip@${hip_version}

--- a/ubuntu/intel/Dockerfile
+++ b/ubuntu/intel/Dockerfile
@@ -6,3 +6,4 @@ ARG intel_version
 ENV intel_version=$intel_version
 
 RUN spack install intel-oneapi-compilers@${intel_version}
+RUN spack view symlink /opt/view intel-oneapi-compilers@${intel_version}


### PR DESCRIPTION
This update will:

 - update base images to install a specific commit from develop
 - add the autamus cache (which should be refreshed shortly) to the base images
 - add a spack view on the PATH so software installed has a consistent version (e.g., gcc)