### PR TITLE
Update dockerfile to use simpler cache method of pulling

### DIFF
--- a/.github/workflows/dockerfiles.yaml
+++ b/.github/workflows/dockerfiles.yaml
@@ -133,14 +133,6 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
 
-    - name: Setup Docker cache
-      uses: actions/cache@v2
-      with:
-        path: /docker.cache
-        key: ${{ runner.os }}-docker-${{ matrix.result.name }}
-        restore-keys: |
-          ${{ runner.os }}-docker
-
     - name: Make Space For Build
       run: |
           sudo rm -rf /usr/share/dotnet
@@ -160,16 +152,13 @@ jobs:
         printf "Container is ${container}\n"
         cat ${{ matrix.result.name }}
         cd $basedir
-        docker build --cache-from=type=local,/docker.cache --cache-to=type=local,mode=max,/docker.cache.tmp -f ${dockerfile} -t ghcr.io/rse-radiuss/${container}:${tag} .
-        echo ::set-output name=container_uri::ghcr.io/rse-radiuss/${container}:${tag}
+        container_name=ghcr.io/rse-radiuss/${container}:${tag}
+        docker pull ${container_name} || echo "Container $container_name does not exist yet"
+        docker build -f ${dockerfile} -t ${container_name} .
+        echo ::set-output name=container_uri::${container_name}
         echo ::set-output name=uri::ghcr.io/rse-radiuss/${container}
         echo ::set-output name=tag::${tag}
         echo ::set-output name=dockerfile_dir::${basedir}
-
-    - name: Update Docker cache
-      run: |
-        rm -rf /docker.cache
-        mv /docker.cache.tmp /docker.cache
 
     - name: Deploy Container
       if: (github.event_name != 'pull_request')


### PR DESCRIPTION
Looks like I broke the more complicated cache method that requires buildx. I say we revert to the simpler method that will work without build x - pulling the previous image (if it exists) and calling it a day.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>